### PR TITLE
Fix postgresql pulse, add default pulse path, and refactorings

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -6,11 +6,12 @@ h3. Authors
 
 * "Paul Gross":http://www.prgs.net
 * "Jesse Newland":http://jnewland.com
+* "Josh Nichols":http://technicalpickles.com
 
 h2. Requirements
 
 * Rails
-* MySQL, Postgres, or Oracle. sqlite not supported, sorry.
+* MySQL, Postgres, or sqlite
 
 h2. Installation
 
@@ -28,7 +29,9 @@ In your @config/routes.rb@:
 
 <pre>
   <code>
-    pulse '/my/pulse/url'
+    pulse
+    # or customize the URL
+    pulse '/admin/pulse'
   </code>
 </pre>
 
@@ -56,7 +59,9 @@ Finally, add a route to config/routes.rb:
 
 <pre>
   <code>
-    map.pulse 'pulse'
+    map.pulse
+    # or customize the URL
+    map.pulse '/admin/pulse'
   </code>
 </pre>
 

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,2 @@
-require File.dirname(__FILE__) + "/lib/rails-pulse"
+$LOAD_PATH.unshift File.dirname(__FILE__) + "/lib"
+require 'rails-pulse'

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -22,6 +22,8 @@ class PulseController < ActionController::Base
     end
   end
 
+  protected 
+
   #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -1,11 +1,10 @@
 class PulseController < ActionController::Base
   session :off unless Rails::VERSION::STRING >= "2.3"
 
-  #The pulse action. Runs <tt>select 1</tt> on the DB. If a sane result is
-  #returned, 'OK' is displayed and a 200 response code is returned. If not,
-  #'ERROR' is returned along with a 500 response code.
+  # The pulse action. Runs <tt>select 1</tt> on the DB. If a sane result is
+  # returned, 'OK' is displayed and a 200 response code is returned. If not,
+  # 'ERROR' is returned along with a 500 response code.
   def pulse
-
     adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
 
     health_method = "#{adapter}_healthy?"
@@ -24,7 +23,7 @@ class PulseController < ActionController::Base
 
   protected 
 
-  #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
+  # cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil
   end

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -5,18 +5,73 @@ class PulseController < ActionController::Base
   #returned, 'OK' is displayed and a 200 response code is returned. If not,
   #'ERROR' is returned along with a 500 response code.
   def pulse
-    if (ActiveRecord::Base::connection_pool.spec.adapter_method =~ /mysql2/) &&
-      ((ActiveRecord::Base.connection.execute("select 1 from dual").count rescue 0) == 1)
-      render :text => "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
-    elsif (ActiveRecord::Base.connection.execute("select 1 from dual").num_rows rescue 0) == 1
-      render :text => "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
+
+    adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
+
+    health_method = "#{adapter}_healthy?"
+    activerecord_okay = if respond_to?(health_method)
+                          send(health_method)
+                        else
+                          raise "Don't know how to check #{adapter}... please to fix?"
+                        end
+
+    if activerecord_okay
+      render :text => okay_response
     else
-      render :text => '<html><body>ERROR</body></html>', :status => :internal_server_error
+      render :text => error_response, :status => :internal_server_error
     end
   end
 
   #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil
+  end
+
+  def sqlite3_healthy?
+    select_one_count == 1
+  end
+
+  def mysql_healthy?
+    select_one_from_dual_num_rows == 1
+  end
+
+  def mysql2_healthy?
+    select_one_from_dual_count == 1
+  end
+
+  def postgresql_healthy?
+    select_one_count == 1
+  end
+
+  def select_one_count
+    count = begin
+              ActiveRecord::Base.connection.execute("select 1").count
+            rescue
+              0
+            end
+  end
+
+  def select_one_from_dual_count
+    begin
+      ActiveRecord::Base.connection.execute("select 1 from dual").count
+    rescue
+      0
+    end
+  end
+
+  def select_one_from_dual_num_rows
+    begin
+      ActiveRecord::Base.connection.execute("select 1 from dual").num_rows
+    rescue
+      0
+    end
+  end
+
+  def okay_response
+    "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
+  end
+
+  def error_response
+    '<html><body>ERROR</body></html>'   
   end
 end

--- a/lib/pulse/helper.rb
+++ b/lib/pulse/helper.rb
@@ -1,2 +1,4 @@
+# some versions of Rails expect there to be a helper for each controller
+# soooo... fake it out
 module PulseHelper
 end

--- a/lib/pulse/routes.rb
+++ b/lib/pulse/routes.rb
@@ -1,6 +1,7 @@
 module Pulse
   module Routes
-    def pulse(path)
+    def pulse(path = nil)
+      path ||= "/pulse"
       if Rails::VERSION::MAJOR == 2
         connect path, :controller => 'pulse', :action => 'pulse'
       else


### PR DESCRIPTION
I tried adding pulse to a postgresql app recently, and it failed because the `dual` table didn't exist. This seems to be a mysql thing, based on my poking around.

The action was pretty hard to read, with some duplication, and ambiguity of what was actually being checked for what adapter. Hopefully, this reads a lot better, and it's more obvious what to do for adding other adapters.

I also added a default pulse path, ie /pulse, since that is what we end up using 99% of the time.

While testing, also found the init.rb was not working.

What I've tested against, and is working:
- Rails 3.2 w/ mysql2
- Rails 3.2 w/ pg
- Rails 3.2 w/ sqlite3
- Rails 2.3 w/ mysql
