### PR TITLE
Check for protected health methods in Ruby 2.0 too.

### DIFF
--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -8,7 +8,10 @@ class PulseController < ActionController::Base
     adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
 
     health_method = "#{adapter}_healthy?"
-    activerecord_okay = if respond_to?(health_method)
+
+    # Need to include all methods in respond_to? because Ruby 2.0 returns false
+    # even for protected methods.
+    activerecord_okay = if respond_to?(health_method, true)
                           send(health_method)
                         else
                           raise "Don't know how to check #{adapter}... please to fix?"


### PR DESCRIPTION
Starting with Ruby 2.0 respond_to? returns false for protected methods too unless they are included with the second parameter set to true. In older Ruby versions only private methods were excluded this way.

Please see difference between method description:
http://ruby-doc.org/core-2.0/Object.html#method-i-respond_to-3F
http://ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F

Blog post about this topic:
http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html

Thanks
Jörg
