### PR TITLE
Support Rails 5

### DIFF
--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 class PulseController < ActionController::Base
   session :off unless Rails::VERSION::STRING >= "2.3"
 
@@ -26,9 +27,8 @@ class PulseController < ActionController::Base
 
   protected 
 
-  # cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
-    nil
+    OpenStruct.new
   end
 
   def sqlite3_healthy?

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -19,9 +19,10 @@ class PulseController < ActionController::Base
                         end
 
     if activerecord_okay
-      render :text => okay_response
+      render response_for_rails_version(Rails::VERSION::STRING, okay_response)
     else
-      render :text => error_response, :status => :internal_server_error
+      render response_for_rails_version(Rails::VERSION::STRING, error_response).
+        merge(:status => :internal_server_error)
     end
   end
 
@@ -78,6 +79,14 @@ class PulseController < ActionController::Base
   end
 
   def error_response
-    '<html><body>ERROR</body></html>'   
+    '<html><body>ERROR</body></html>'
+  end
+
+  def response_for_rails_version(rails_version_string, response)
+    if rails_version_string >= "4.1"
+      { :html => response.html_safe }
+    else
+      { :text => response }
+    end
   end
 end

--- a/rails-pulse.gemspec
+++ b/rails-pulse.gemspec
@@ -20,5 +20,9 @@ Gem::Specification.new do |s|
   
   s.add_runtime_dependency "rails"
 
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "multi_rails"
+
   s.rubygems_version = %q{1.2.0}
 end


### PR DESCRIPTION
- After upgrading to Rails 5, the pulse controller errors on calls to `logger.info?`. Pulse was defining `logger` as `nil`. By using an `OpenStruct` calls of logger methods will not error, but it will log nothing as intended.
- `render :text` is deprecated. Replace with `render :html` for Rails versions >= 4.1.
Reference: http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#rendering-content-from-string

I considered bumping the gem version, but I wasn't sure of the versioning process for this gem so I figured I'd leave that to the maintainers. Happy to add a version bump if desired.

Also the test suite depends on the multi_rails gem, but it appears to be out of date. I got an error in the Rakefile, line 2, where it executes `require 'load_multi_rails_rake_tasks'`. If you have any guidance on how to proceed with testing I'll add specs.
